### PR TITLE
Move TEST_REPO into the matrix section by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
   fast_finish: true
 env:
   global:
-  - TEST_REPO=
   - CORE_REPO=
   - GEM_REPOS=
+  matrix:
+  - TEST_REPO=

--- a/README.md
+++ b/README.md
@@ -16,29 +16,30 @@ For more information about the variables or more examples, refer to the
 #### Testing a single repo in the context of ManageIQ PR 12345
 
 ```diff
-@@ -11,6 +11,5 @@ matrix:
+@@ -14,7 +14,7 @@ matrix:
    fast_finish: true
  env:
    global:
--  - TEST_REPO=
 -  - CORE_REPO=
--  - GEM_REPOS=
-+  - TEST_REPO=manageiq-ui-classic
 +  - CORE_REPO=manageiq@12345
+   - GEM_REPOS=
+   matrix:
+-  - TEST_REPO=
++  - TEST_REPO=manageiq-ui-classic
 ```
 
 #### Testing multiple repos in the context of ManageIQ PR 12345
 
 ```diff
-@@ -11,6 +11,7 @@ matrix:
+@@ -14,7 +14,8 @@ matrix:
    fast_finish: true
  env:
    global:
--  - TEST_REPO=
 -  - CORE_REPO=
--  - GEM_REPOS=
 +  - CORE_REPO=manageiq@12345
-+  matrix:
+   - GEM_REPOS=
+   matrix:
+-  - TEST_REPO=
 +  - TEST_REPO=manageiq-ui-classic
 +  - TEST_REPO=manageiq-api
 ```


### PR DESCRIPTION
@agrare Please review.

Since everyone uses matrixes a majority of the time, it's simpler to just have the .travis.yml start out that way to get people going in the right direction.