### PR TITLE
Test core with prerequisites of 19684, without 19684 itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS='ManageIQ/manageiq-providers-amazon#584 ManageIQ/manageiq-providers-azure#374 ManageIQ/manageiq-providers-google#119  ManageIQ/manageiq-providers-kubernetes#353 ManageIQ/manageiq-providers-openstack#547 ManageIQ/manageiq-providers-ovirt#454 ManageIQ/manageiq-providers-vmware#508'
   matrix:
   - TEST_REPO=manageiq


### PR DESCRIPTION
I want to test the dependencies of https://github.com/ManageIQ/manageiq/pull/19684 can be merged before 19684 itself is merged.

I suspect this will fail because multiple `REPOS` currently won't work, working on a fix...
=>
```
Error: ManageIQ/manageiq-providers-amazon#584 ManageIQ/manageiq-providers-azure#374 ManageIQ/manageiq-providers-google#119  ManageIQ/manageiq-providers-kubernetes#353 ManageIQ/manageiq-providers-openstack#547 ManageIQ/manageiq-providers-ovirt#454 ManageIQ/manageiq-providers-vmware#508 does not exist.
```