### PR TITLE
Test core with prerequisites of 19684, without 19684 itself, multi-REPOS support attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS='ManageIQ/manageiq-providers-amazon#584 ManageIQ/manageiq-providers-azure#374 ManageIQ/manageiq-providers-google#119  ManageIQ/manageiq-providers-kubernetes#353 ManageIQ/manageiq-providers-openstack#547 ManageIQ/manageiq-providers-ovirt#454 ManageIQ/manageiq-providers-vmware#508'
   matrix:
   - TEST_REPO=manageiq

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "manageiq-cross_repo", "~> 1.0"
+gem "manageiq-cross_repo", git: "https://github.com/cben/manageiq-cross_repo", branch: "multi-REPOS"


### PR DESCRIPTION
I want to test the dependencies of ManageIQ/manageiq#19684 can be merged before 19684 itself is merged.

#48 failed => Trying running with my changes https://github.com/ManageIQ/manageiq-cross_repo/pull/53 to support multiple space-separated REPOS => works:
```
** override_gem("manageiq-providers-amazon", :path=>"/home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-amazon@0750830647d7d2ff2e1f84319ea12c499e75eaf8") at /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@9837b20cae793f64d64a74c88db78a95eb2f0ffd/bundler.d/overrides.rb:1
** override_gem("manageiq-providers-azure", :path=>"/home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-azure@3d0a7495fdb56790a745eb68df0b698bd4005864") at /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@9837b20cae793f64d64a74c88db78a95eb2f0ffd/bundler.d/overrides.rb:2
** override_gem("manageiq-providers-google", :path=>"/home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-google@20916d880dcae3608c76de3c938b04b5e80438ee") at /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@9837b20cae793f64d64a74c88db78a95eb2f0ffd/bundler.d/overrides.rb:3
** override_gem("manageiq-providers-kubernetes", :path=>"/home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-kubernetes@f94e839d1ddb954f81994e3a38771c1c8ad1225f") at /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@9837b20cae793f64d64a74c88db78a95eb2f0ffd/bundler.d/overrides.rb:4
** override_gem("manageiq-providers-openstack", :path=>"/home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-openstack@502b34b50fa538f006d205f2c793f21d22d5d6aa") at /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@9837b20cae793f64d64a74c88db78a95eb2f0ffd/bundler.d/overrides.rb:5
** override_gem("manageiq-providers-ovirt", :path=>"/home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-ovirt@11c73e0f963960133a6f76ae4667586e6705be6d") at /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@9837b20cae793f64d64a74c88db78a95eb2f0ffd/bundler.d/overrides.rb:6
** override_gem("manageiq-providers-vmware", :path=>"/home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-vmware@87d9348b32549f053f8a0c0714ee55b9ff13c550") at /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@9837b20cae793f64d64a74c88db78a95eb2f0ffd/bundler.d/overrides.rb:7
```