### PR TITLE
Test prerequisites AND core 19684, multi-REPOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS=ManageIQ/manageiq-providers-amazon#584 ManageIQ/manageiq-providers-azure#374 ManageIQ/manageiq-providers-google#119  ManageIQ/manageiq-providers-kubernetes#353 ManageIQ/manageiq-providers-openstack#547 ManageIQ/manageiq-providers-ovirt#454 ManageIQ/manageiq-providers-vmware#508 manageiq#19684
   matrix:
-  - TEST_REPO=manageiq
+  - TEST_REPO=ManageIQ/manageiq-providers-amazon#584
+  - TEST_REPO=ManageIQ/manageiq-providers-azure#374
+  - TEST_REPO=ManageIQ/manageiq-providers-google#119
+  - TEST_REPO=ManageIQ/manageiq-providers-kubernetes#353
+  - TEST_REPO=ManageIQ/manageiq-providers-openstack#547
+  - TEST_REPO=ManageIQ/manageiq-providers-ovirt#454
+  - TEST_REPO=ManageIQ/manageiq-providers-vmware#508
+  - TEST_REPO=manageiq#19684

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=ManageIQ/manageiq-providers-amazon#584 ManageIQ/manageiq-providers-azure#374 ManageIQ/manageiq-providers-google#119  ManageIQ/manageiq-providers-kubernetes#353 ManageIQ/manageiq-providers-openstack#547 ManageIQ/manageiq-providers-ovirt#454 ManageIQ/manageiq-providers-vmware#508 manageiq#19684
+  - REPOS="ManageIQ/manageiq-providers-amazon#584 ManageIQ/manageiq-providers-azure#374 ManageIQ/manageiq-providers-google#119  ManageIQ/manageiq-providers-kubernetes#353 ManageIQ/manageiq-providers-openstack#547 ManageIQ/manageiq-providers-ovirt#454 ManageIQ/manageiq-providers-vmware#508 manageiq#19684"
   matrix:
   - TEST_REPO=ManageIQ/manageiq-providers-amazon#584
   - TEST_REPO=ManageIQ/manageiq-providers-azure#374

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "manageiq-cross_repo", "~> 1.0"
+gem "manageiq-cross_repo", git: "https://github.com/cben/manageiq-cross_repo", branch: "multi-REPOS"


### PR DESCRIPTION
Similar to #49 but this time including #19684 itself.
Largely to experiment more with multi-repo injection via REPOS before I document it...

- In #49 I used `REPOS='foo bar'` syntax with shell quoting of the space.  It worked.
  ~~Now trying without quotes `REPOS=foo bar`...~~

- Now also running many TEST_REPO values, core and each changed provider.
  I think in this case the core changes shouldn't affect back the provider tests, but as I said I want to play with test injection :)
  The more "correct" way to express this would be to avoid repeating TEST_REPO in REPOS, which requires carefully setting both in matrix (`REPOS='a b' TEST_REPO=c`, `REPOS='a c' TEST_REPO=b`, ...).  But that's cumbersome, and the task of "test all repos with all changes" is common, so I want to check if a fixed REPOS list overlapping with TEST_REPO will work?