### PR TITLE
latest 5-2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,19 @@ matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS=kbrock/manageiq@rails-5-2-b,manageiq-consumption#172,jrafanie/manageiq-schema@try_rails_5_2
   matrix:
-  - TEST_REPO=manageiq
+  - TEST_REPO=kbrock/manageiq@rails-5-2-b
+  - TEST_REPO=manageiq-ui-classic
+  - TEST_REPO=jrafanie/manageiq-schema@try_rails_5_2
+  - TEST_REPO=manageiq-api
+  - TEST_REPO=manageiq-automation_engine
+  - TEST_REPO=manageiq-providers-amazon
+  - TEST_REPO=manageiq-providers-azure
+  - TEST_REPO=manageiq-providers-google
+  - TEST_REPO=manageiq-providers-kubernetes
+  - TEST_REPO=manageiq-providers-openstack
+  - TEST_REPO=manageiq-providers-openshift
+  - TEST_REPO=manageiq-providers-ovirt
+  - TEST_REPO=manageiq-providers-scvmm
+  - TEST_REPO=manageiq-providers-vmware


### PR DESCRIPTION
This uses [kbrock-rails-5-2-b](https://github.com/ManageIQ/manageiq/compare/master...kbrock:rails-5-2-b ) which is a rebase of [jrafanie rails-5-2](https://github.com/ManageIQ/manageiq/compare/master...jrafanie:rails-5-2) with 20110 thrown on top

- https://github.com/ManageIQ/manageiq-consumption/pull/172
- https://github.com/ManageIQ/manageiq/issues/20032
- https://github.com/ManageIQ/manageiq/pull/20110
