### PR TITLE
Cross repo tests for gems-pending #470 (remove MiqSshUtil)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
   - TEST_REPO=manageiq
   - TEST_REPO=manageiq-api
   - TEST_REPO=manageiq-automation_engine
-  - TEST_REPO=manageiq-release
   - TEST_REPO=manageiq-ui-classic
   - TEST_REPO=manageiq-smartstate
   - TEST_REPO=manageiq-providers-ansible_tower
@@ -30,4 +29,3 @@ env:
   - TEST_REPO=manageiq-providers-nuage
   - TEST_REPO=manageiq-providers-openshift
   - TEST_REPO=manageiq-providers-vmware
-  - TEST_REPO=more_core_extensions

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,20 @@ matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS=manageiq-gems-pending#470
   matrix:
   - TEST_REPO=manageiq
+  - TEST_REPO=manageiq-api
+  - TEST_REPO=manageiq-automation_engine
+  - TEST_REPO=manageiq-release
+  - TEST_REPO=manageiq-ui-classic
+  - TEST_REPO=manageiq-smartstate
+  - TEST_REPO=manageiq-providers-ansible_tower
+  - TEST_REPO=manageiq-providers-azure
+  - TEST_REPO=manageiq-providers-foreman
+  - TEST_REPO=manageiq-providers-kubernetes
+  - TEST_REPO=manageiq-providers-lenovo
+  - TEST_REPO=manageiq-providers-nuage
+  - TEST_REPO=manageiq-providers-openshift
+  - TEST_REPO=manageiq-providers-vmware
+  - TEST_REPO=more_core_extensions


### PR DESCRIPTION
With MiqSshUtil now manageiq-ssh-util, this tests to see if we can remove the old library from gems-pending:

https://github.com/ManageIQ/manageiq-gems-pending/pull/470