### PR TITLE
test everything with a more_core_extension bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS=manageiq-gems-pending#481
   matrix:
+  - TEST_REPO=manageiq-gems-pending#481
   - TEST_REPO=manageiq


### PR DESCRIPTION
more core ext's on 4.1.0 and we're locked to 3 in the following nine places:
~~core~~, ui, ~~schema~~, ~~linux_admin~~, ~~openstack~~, ~~ansible tower client~~, ~~inventory refresh~~, ~~vmware web services~~, ~~kube~~
