### PR TITLE
cleanup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
-dist: xenial
 language: ruby
 rvm:
 - 2.5.5
-cache:
-  bundler: true
+cache: bundler
 addons:
   postgresql: '10'
   apt:


### PR DESCRIPTION
since we're not specifying directories to cache, we could one line the bundler line; we don't need to specify the distro here either