### PR TITLE
Only run the master branch and not bot branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ addons:
 script: bundle exec manageiq-cross_repo
 matrix:
   fast_finish: true
+branches:
+  only:
+  - master
 env:
   global:
   - REPOS=


### PR DESCRIPTION
Prior to this, Travis would do branch builds in addition to PR builds for branches created directly in this repo (for example by the automated bot created branches).  This effectively runs the tests twice which is not useful.  This PR blocks the runs of those extra branch builds.