### PR TITLE
test api change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,72 @@ branches:
   - master
 env:
   global:
-  - REPOS=
+  - REPOS=manageiq-api#961
   matrix:
   - TEST_REPO=manageiq
+  - TEST_REPO=manageiq-api#961
+  - TEST_REPO=manageiq-automation_engine
+  - TEST_REPO=manageiq-consumption
+  - TEST_REPO=manageiq-content
+  - TEST_REPO=manageiq-decorators
+  - TEST_REPO=manageiq-gems-pending
+  - TEST_REPO=manageiq-graphql
+  - TEST_REPO=manageiq-schema
+  - TEST_REPO=manageiq-ui-classic
+  - TEST_REPO=manageiq-ui-service
+  - TEST_REPO=manageiq-v2v
+  - TEST_REPO=manageiq-providers-amazon
+  - TEST_REPO=manageiq-providers-ansible_tower
+  - TEST_REPO=manageiq-providers-autosde
+  - TEST_REPO=manageiq-providers-azure
+  - TEST_REPO=manageiq-providers-azure_stack
+  - TEST_REPO=manageiq-providers-foreman
+  - TEST_REPO=manageiq-providers-google
+  - TEST_REPO=manageiq-providers-ibm_cloud
+  - TEST_REPO=manageiq-providers-ibm_terraform
+  - TEST_REPO=manageiq-providers-kubernetes
+  - TEST_REPO=manageiq-providers-kubevirt
+  - TEST_REPO=manageiq-providers-lenovo
+  - TEST_REPO=manageiq-providers-nsxt
+  - TEST_REPO=manageiq-providers-nuage
+  - TEST_REPO=manageiq-providers-openshift
+  - TEST_REPO=manageiq-providers-openstack
+  - TEST_REPO=manageiq-providers-ovirt
+  - TEST_REPO=manageiq-providers-redfish
+  - TEST_REPO=manageiq-providers-scvmm
+  - TEST_REPO=manageiq-providers-vmware
+
+# Convenience list of repos for copy/paste
+#
+# manageiq-api
+# manageiq-automation_engine
+# manageiq-consumption
+# manageiq-content
+# manageiq-decorators
+# manageiq-gems-pending
+# manageiq-graphql
+# manageiq-schema
+# manageiq-ui-classic
+# manageiq-ui-service
+# manageiq-v2v
+#
+# manageiq-providers-amazon
+# manageiq-providers-ansible_tower
+# manageiq-providers-autosde
+# manageiq-providers-azure
+# manageiq-providers-azure_stack
+# manageiq-providers-foreman
+# manageiq-providers-google
+# manageiq-providers-ibm_cloud
+# manageiq-providers-ibm_terraform
+# manageiq-providers-kubernetes
+# manageiq-providers-kubevirt
+# manageiq-providers-lenovo
+# manageiq-providers-nsxt
+# manageiq-providers-nuage
+# manageiq-providers-openshift
+# manageiq-providers-openstack
+# manageiq-providers-ovirt
+# manageiq-providers-redfish
+# manageiq-providers-scvmm
+# manageiq-providers-vmware


### PR DESCRIPTION
i just wanted to see about https://github.com/ManageIQ/manageiq-api/pull/961

the failures are all expected and aren't related to changes made in 961: 

- [content is currently red](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/433221782#L2466) because of an ansible cred test that broke before 961
- the [automate engine specs are red](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/433221780#L2474) cause of a openstack factory change
- [manageiq-ui-service is failing](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/433221788#L326) because it can't be run by cross_repo_tests
- the [graphql failures](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/433221785#L2472) are unrelated: 

```
Failure/Error: Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
NameError: uninitialized constant RSpec::Mocks::ExampleMethods
```
---
as of nov 19, all these save the service ui should pass now except 
- [the api](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/443938019#L2435) is current red for unrelated reasons
- ditto [azure_stack](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/443938034#L2495)
---
as of dec 2:
- only [the expected service ui failure](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/452650587#L293)