### PR TITLE
Debug ManageIQ w/Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,16 @@ addons:
   apt:
     packages:
     - libarchive-dev
-script: bundle exec manageiq-cross_repo
+script: echo $RAILS_COMMIT; bundle exec manageiq-cross_repo
 matrix:
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS=NickLaMuro/manageiq@rails-6-debug,NickLaMuro/activerecord-id_regions@rails-6-debug,ManageIQ/manageiq-api#963,NickLaMuro/manageiq-gems-pending@rails-6-debug,NickLaMuro/manageiq-graphql@rails-6-debug,NickLaMuro/inventory_refresh@rails-6-debug,ManageIQ/jquery-rjs#2,NickLaMuro/manageiq-postgres_ha_admin@rails-6-debug,ManageIQ/manageiq-providers-ansible_tower#246,ManageIQ/manageiq-providers-lenovo#322,ManageIQ/manageiq-providers-nsxt#27,NickLaMuro/manageiq-providers-openstack@rails-6-debug,NickLaMuro/manageiq-schema@rails-6-debug,NickLaMuro/manageiq-ui-classic@rails-6-debug,NickLaMuro/ovirt_metrics@rails-6-debug,NickLaMuro/vmware_web_service@rails-6-debug
+  - RAILS_COMMIT=0f0aa6a275876502e002c054896734d6536ba5cd
+  - BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM=true
   matrix:
-  - TEST_REPO=manageiq
+  - TEST_REPO=NickLaMuro/manageiq-graphql@rails-6-debug
 
 # Convenience list of repos for copy/paste
 #

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,15 @@
 source "https://rubygems.org"
 
-gem "manageiq-cross_repo", "~> 1.0"
+# gem "manageiq-cross_repo", "~> 1.0"
+
+# Use custom branch of `manageiq-cross_repo` to allow bisecting rails for
+# debugging purposes and custom modifications.
+#
+# This will be experimental and suseptable to false negatives (since using a
+# particular version of activerecord with a locked version of rails is most
+# likely going to fail.  Experimentation of bisecting all of rails or just
+# activerecord is going to have to happen to deterime the best course of
+# action.
+#
+gem "manageiq-cross_repo", :git    => "https://github.com/NickLaMuro/manageiq-cross_repo",
+                           :branch => "rails-bisect"


### PR DESCRIPTION
Debugging PR for https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/179 to deal with errors that cannot be replicated locally.

Specifically, this error:

```
Seeding :schema_migrations_ran table...
rails aborted!
PG::ConnectionBad: connection is closed
pg-1.2.3/lib/pg/basic_type_mapping.rb:115:in `server_version'
pg-1.2.3/lib/pg/basic_type_mapping.rb:115:in `supports_ranges?'
pg-1.2.3/lib/pg/basic_type_mapping.rb:119:in `build_coder_maps'
pg-1.2.3/lib/pg/basic_type_mapping.rb:402:in `initialize'
pg-logical_replication-1.0.0/lib/pg/logical_replication/client.rb:316:in `new'
pg-logical_replication-1.0.0/lib/pg/logical_replication/client.rb:316:in `typed_exec'
pg-logical_replication-1.0.0/lib/pg/logical_replication/client.rb:158:in `subscriptions'
manageiq/app/models/pglogical_subscription.rb:177:in `subscriptions'
manageiq/app/models/pglogical_subscription.rb:182:in `find_all'
manageiq/app/models/pglogical_subscription.rb:19:in `find'
manageiq/lib/acts_as_ar_model.rb:156:in `search'
query_relation-0.1.1/lib/query_relation.rb:48:in `block in initialize'
query_relation-0.1.1/lib/query_relation.rb:181:in `call_query_method'
query_relation-0.1.1/lib/query_relation.rb:145:in `to_a'
manageiq/lib/tasks/evm_dbsync.rake:26:in `block (3 levels) in <top (required)>'
manageiq/lib/tasks/test.rake:35:in `block (2 levels) in <top (required)>'
manageiq/lib/tasks/test_vmdb.rake:22:in `block (3 levels) in <top (required)>'
railties-6.0.3.4/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
railties-6.0.3.4/lib/rails/commands/rake/rake_command.rb:20:in `perform'
railties-6.0.3.4/lib/rails/command.rb:48:in `invoke'
railties-6.0.3.4/lib/rails/commands.rb:18:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => evm:dbsync:resync_excludes
(See full trace by running task with --trace)
```