### PR TITLE
Test travis bundler cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
 - 2.5.5
-cache: bundler
+cache:
+  directories:
+  - vendor/bundle
 addons:
   postgresql: '10'
   apt:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "manageiq-cross_repo", "~> 1.0"
+gem "manageiq-cross_repo", "~> 1.1"


### PR DESCRIPTION
Use custom cache directories to prevent `bundle clean` from removing the test-repo's cached gems.  This method is recommended by: https://docs.travis-ci.com/user/caching/#cleaning-up-bundle

Ref: https://github.com/ManageIQ/manageiq-cross_repo/pull/71#issuecomment-783534495