### PR TITLE
Use ruby 2.6 now that 2.5 has been dropped from core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.5.5
+- 2.6.6
 cache:
   directories:
   - vendor/bundle


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq/pull/21095

Standard `@miq-bot cross-repo-tests` are failing due to the base .travis.yml using ruby 2.5.5

```
[!] There was an error parsing `Gemfile`: Ruby versions < 2.6.0 are unsupported!. Bundler cannot continue.

 #  from /home/travis/build/ManageIQ/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@6f2c8374c831bdbc301f30ecacca8b338ff77046/Gemfile:1
 #  -------------------------------------------
 >  raise "Ruby versions < 2.6.0 are unsupported!" if RUBY_VERSION < "2.6.0"
 #  raise "Ruby versions >= 3.0.0 are unsupported!" if RUBY_VERSION >= "3.0.0"
 #  -------------------------------------------
The command "bundle exec manageiq-cross_repo" exited with 4.
cache.2
store build cache

Done. Your build exited with 1.
```

https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/492294635#L339-L351