### PR TITLE
Add script and GitHub action to close orphaned PRs

### DIFF
--- a/.github/workflows/close_prs.yaml
+++ b/.github/workflows/close_prs.yaml
@@ -1,0 +1,22 @@
+---
+name: Close PRs
+
+on:
+  schedule:
+  - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  close-prs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "ruby"
+      timeout-minutes: 30
+    - name: Close PRs
+      env:
+        GITHUB_API_TOKEN: "${{ secrets.PR_TOKEN }}"
+      run: bin/close_prs

--- a/bin/close_prs
+++ b/bin/close_prs
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+require "bundler/inline"
+gemfile do
+  source "https://rubygems.org"
+  gem "colorize"
+  gem "octokit"
+  gem "optimist"
+end
+
+opts = Optimist.options do
+  opt :dry_run, "Execute without making changes", :default => false
+end
+
+def close_pull_request(repo, number, dry_run:, **_)
+  if dry_run
+    puts "** dry_run: github.close_pull_request(#{repo.inspect}, #{number.inspect})".light_black
+  else
+    github.close_pull_request(repo, number)
+  end
+end
+
+def delete_branch(repo, branch, dry_run:, **_)
+  if dry_run
+    puts "** dry_run: github.delete_branch(#{repo.inspect}, #{branch.inspect})".light_black
+  else
+    github.delete_branch(repo, branch)
+  end
+end
+
+def github
+  @github ||= Octokit::Client.new(
+    :access_token  => ENV.fetch("GITHUB_API_TOKEN"),
+    :auto_paginate => true
+  )
+end
+
+CRT_REPO = "ManageIQ/manageiq-cross_repo-tests".freeze
+
+github.pull_requests(CRT_REPO, :state => "open").each do |crt_pr|
+  target = crt_pr.title.split(" ").last
+  next unless target.match?(%r{^ManageIQ/[^#]+#\d+$})
+
+  repo, number = target.split("#")
+  pr = github.pull_request(repo, number)
+
+  crt_pr_slug = "#{CRT_REPO}##{crt_pr.number}"
+  pr_slug = "#{repo}##{number}"
+
+  if pr.state == "closed"
+    puts "Closing #{crt_pr_slug} since #{pr_slug} is closed"
+    close_pull_request(CRT_REPO, crt_pr.number, **opts)
+    puts "Deleting branch #{crt_pr.head.ref}"
+    delete_branch(CRT_REPO, crt_pr.head.ref, **opts)
+  else
+    puts "Skipping #{crt_pr_slug} since #{pr_slug} is open"
+  end
+end


### PR DESCRIPTION
This script automatically detects "orphaned" PRs in this repo, by looking at the source PR, and if it is closed, will close the cross-repo-test PR.

Additionally this adds a GitHub action to run it every Sunday.

@agrare Please review. Since this doesn't have the push or pull_request event trigger, I can't figure out how to run it before a PR. That said, I tested locally and in ACT (and ran it for real, so you'll notice a lot of closed PRs)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
