### PR TITLE
Use shared manageiq_cross_repo.yaml GHA from a tag not master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   cross-repo:
-    uses: ManageIQ/manageiq-cross_repo/.github/workflows/manageiq_cross_repo.yaml@master
+    uses: ManageIQ/manageiq-cross_repo/.github/workflows/manageiq_cross_repo.yaml@v2.5.0
     with:
       test-repos: '["ManageIQ/manageiq@master"]'
       repos: ManageIQ/manageiq@master

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "manageiq-cross_repo", "~> 2.0"
+gem "manageiq-cross_repo", "~> 2.5"


### PR DESCRIPTION
We had been using the manageiq_cross_repo github action workflow straight from the master branch not a tag.  This can introduce issues where we might want to make "breaking" changes but not have them picked up by other repos.

Ref: https://github.com/ManageIQ/manageiq-cross_repo/pull/127#issuecomment-5169800390
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
